### PR TITLE
Update Converter.php

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -126,7 +126,7 @@ class Converter implements ConverterInterface
             }
         });
 
-        $result = $this->createOutput($inputFile . '.' . $parameters->getOutputFormat(), $parameters->getOutputFile());
+        $result = $this->createOutput($inputFile, $parameters->getOutputFile());
         $this->deleteInput($parameters, $inputFile);
 
         if ($resultCode != 0) {


### PR DESCRIPTION
`$inputFile` will be temp-file in all cases, generated without corresponding output-format suffix. So for example with outputFormat `Format::TEXT_PDF` like this: 
```php
$converter = new Converter();
$lowrapperParameters = new LowrapperParameters();
$lowrapperParameters->setInputFile($sourceFile);
$lowrapperParameters->setDocumentType(DocumentType::WEB);
$lowrapperParameters->setOutputFile($targetFile);
$lowrapperParameters->setOutputFormat(Format::TEXT_PDF);
$converter->convert($lowrapperParameters);
```
The command will be something like
`libreoffice --headless --invisible --nocrashreport --nodefault --nofirststartwizard --nologo --norestore --web --convert-to "pdf" "/tmp/lowrapper_58930caab4578"` 
So the input-file doesnt have ".pdf" extension.
Am i missing something?