### PR TITLE
install instruction for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ More [examples](/examples)
 
 ## Installation
 
+##### On Linux-based systems
+
 ```bash
 sudo add-apt-repository ppa:libreoffice/ppa
 sudo apt-get update
@@ -49,6 +51,8 @@ sudo apt-get install libreoffice-core --no-install-recommends
 sudo apt-get install libreoffice-writer
 composer require mnvx/lowrapper
 ```
+
+##### Inside a Docker container
 
 Example of installation libreoffice into docker container:
 
@@ -65,6 +69,30 @@ RUN mkdir -p /var/www/.cache/dconf \
     && mkdir -p /var/www/.config/libreoffice \
     && chmod -R ugo+rwx /var/www/.cache \
     && chmod -R ugo+rwx /var/www/.config
+```
+
+##### On macOS
+
+Watch out! For weird reasons, the LibreOffice command line binary has a non-obvious name on macOS:
+`soffice`, probably because until 2010 the software was named StarOffice.
+Install the necessary Java Development Kit (which is needed for LibreOffice to run) and LibreOffice
+itself for example with the packet manager [brew](https://brew.sh):
+
+```
+brew install openjdk
+brew install libreoffice
+```
+Check if LibreOffice is installed correctly:
+
+```
+soffice -v
+# should show
+# LibreOffice 7.0.x.x
+```
+And in your code tell the Converter the name of the binary:
+
+```
+$converter = new Converter('soffice');
 ```
 
 ## Run tests


### PR DESCRIPTION
On macOS, things are a bit tricky, so I added install instructions for JDK and LibreOffice (incl. command line tool) and making it all run together smoothly.