### PR TITLE
compatibility fix with new sf versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^7.2|^8.0",
     "symfony/process": "^3.1|^4.1|^5.0|^6.0",
-    "psr/log": "^1.0"
+    "psr/log": "^1|^2|^3"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
Installing in new symfony versions like 5 or 6 psr/log locked to ^1.0 block composer installation